### PR TITLE
Add command-line argument support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,6 +133,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "cfg-if"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "clap"
+version = "2.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "cloudabi"
@@ -1194,6 +1216,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "syn"
 version = "0.15.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1243,6 +1270,14 @@ version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "wincolor 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1437,6 +1472,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-width"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1477,6 +1517,11 @@ dependencies = [
 [[package]]
 name = "vcpkg"
 version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "vec_map"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1567,6 +1612,7 @@ name = "xkcdfs"
 version = "0.1.0"
 dependencies = [
  "cairo-rs 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuse 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jpeg-decoder 0.1.16 (git+https://github.com/danieldulaney/jpeg-decoder.git?branch=pixel-format-sizes)",
@@ -1583,6 +1629,7 @@ dependencies = [
 [metadata]
 "checksum adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
+"checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d73f9beda665eaa98ab9e4f7442bd4e7de6652587de55b2525e52e29c1b0ba"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
@@ -1597,6 +1644,7 @@ dependencies = [
 "checksum cairo-sys-rs 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "90a1ec04603a78c111886a385edcec396dbfbc57ea26b9e74aeea6a1fe55dcca"
 "checksum cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc9a35e1f4290eb9e5fc54ba6cf40671ed2a2514c3eeb2b2a908dda2ea5a1be"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
+"checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5"
 "checksum cookie_store 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46750b3f362965f197996c4448e4a0935e791bf7d6631bfce9ee0af3d24c919c"
@@ -1719,11 +1767,13 @@ dependencies = [
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
+"checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
+"checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread-scoped 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bcbb6aa301e5d3b0b5ef639c9a9c7e2f1c944f177b460c04dc24c69b1fa2bd99"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
@@ -1743,12 +1793,14 @@ dependencies = [
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-linebreak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4e30c7c3c3fa01e2c0da7008b57c2e5414b132a27fdf797e49e5ecbfe4f4b150"
 "checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
+"checksum unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75b414f6c464c879d7f9babf951f23bc3743fb7313c081b2e6ca719067ea9d61"
 "checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
 "checksum vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "33dd455d0f96e90a75803cfeb7f948768c08d70a6de9a8d2362461935698bf95"
+"checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum want 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
 "checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,11 @@
 name = "xkcdfs"
 version = "0.1.0"
 authors = ["Daniel Dulaney <dan@dulaney.xyz>"]
+description = "Browse xkcd in comfort and style"
 edition = "2018"
 
 [dependencies]
-# FUSE and some dependencies I need access to
+# FUSE and some needed sub-dependencies
 fuse = "0.3.1"
 libc = "*"
 time = "*"
@@ -28,6 +29,9 @@ unicode-linebreak = "0.1.0"
 # For logging
 log = "*"
 env_logger = "0.7"
+
+# For command-line parsing
+clap = "2.33"
 
 [patch.crates-io]
 jpeg-decoder = { git = "https://github.com/danieldulaney/jpeg-decoder.git", branch = "pixel-format-sizes" }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,63 @@
+use clap::{App, Arg};
+use std::ffi::OsString;
+
+pub fn get_args() -> Option<(u64, OsString, OsString)> {
+    let matches = App::new(env!("CARGO_PKG_NAME"))
+        .version(env!("CARGO_PKG_VERSION"))
+        .author(env!("CARGO_PKG_AUTHORS"))
+        .about(env!("CARGO_PKG_DESCRIPTION"))
+        .arg(
+            Arg::with_name("path")
+                .help("Path where the filesystem will be mounted")
+                .value_name("PATH")
+                .required(true)
+                .index(1),
+        )
+        .arg(
+            Arg::with_name("database")
+                .help("Database file location")
+                .short("d")
+                .long("database")
+                .value_name("FILE")
+                .default_value(":memory:")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("timeout")
+                .value_name("SECONDS")
+                .help("Timeout for web requests")
+                .short("t")
+                .long("timeout")
+                .default_value("5"),
+        )
+        .get_matches();
+
+    // Pull out command-line arguments
+    let timeout = match matches.value_of("timeout").map(str::parse::<u64>) {
+        None => {
+            error!("Could not determine timeout value");
+            return None;
+        }
+        Some(Err(e)) => {
+            error!("Could not parse timeout as an integer: {}", e);
+            return None;
+        }
+        Some(Ok(t)) => t,
+    };
+    let path = match matches.value_of_os("path") {
+        None => {
+            error!("Could not determine mount path");
+            return None;
+        }
+        Some(p) => p,
+    };
+    let database = match matches.value_of_os("database") {
+        None => {
+            error!("Could not determine database location");
+            return None;
+        }
+        Some(d) => d,
+    };
+
+    Some((timeout, path.to_owned(), database.to_owned()))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 extern crate log;
 
+mod cli;
 mod fs;
 mod image;
 mod requests;
@@ -11,20 +12,25 @@ pub use requests::XkcdClient;
 pub use xkcd::Comic;
 
 use requests::RequestMode::*;
-use std::env;
 use std::ffi::OsStr;
+use std::time::Duration;
 
 fn main() {
     env_logger::init();
 
-    let client = XkcdClient::new(std::time::Duration::from_secs(5));
+    let (timeout, mountpoint, database) = match cli::get_args() {
+        Some(args) => args,
+        None => return,
+    };
+
+    let client = XkcdClient::new(Duration::from_secs(timeout), &database);
 
     info!("Requesting latest comic (to get file count)");
 
     let latest_comic = match client.request_latest_comic(None, BustCache) {
         Some(c) => c,
         None => {
-            error!("Could not fetch latest comic from https://xkcd.com.");
+            error!("Could not fetch latest comic from https://xkcd.com");
             error!("Are you connected to the Internet?");
             return;
         }
@@ -34,15 +40,7 @@ fn main() {
 
     let fs = fs::XkcdFs::new(client);
 
-    let mountpoint = match env::args_os().nth(1) {
-        None => {
-            error!("No mountpoint (use a command line argument)");
-            return;
-        }
-        Some(s) => s,
-    };
-
-    let options = ["-o", "fsname=xkcd"]
+    let options = ["-o", "fsname=xkcdfs"]
         .iter()
         .map(|o| o.as_ref())
         .collect::<Vec<&OsStr>>();

--- a/src/requests/mod.rs
+++ b/src/requests/mod.rs
@@ -1,10 +1,9 @@
 use crate::Comic;
+use std::ffi::OsStr;
 use std::time::Duration;
 
 mod api;
 mod database;
-
-static SQLITE_DB: &str = "/dev/shm/test.db";
 
 #[derive(Clone, Debug)]
 pub enum RequestMode {
@@ -49,13 +48,13 @@ pub struct XkcdClient {
 }
 
 impl XkcdClient {
-    pub fn new(master_timeout: Duration) -> Self {
+    pub fn new(master_timeout: Duration, database: &OsStr) -> Self {
         let new = Self {
             client: reqwest::Client::builder()
                 .timeout(master_timeout)
                 .build()
                 .unwrap(),
-            conn: rusqlite::Connection::open(SQLITE_DB).expect("Failed to connect to SQLite DB"),
+            conn: rusqlite::Connection::open(database).expect("Failed to connect to SQLite DB"),
         };
 
         database::setup(&new.conn).expect("Failed to set up SQLite DB");


### PR DESCRIPTION
Add command-line argument support, including:
- clap, a new dependency
- Required mountpoint
- Configurable database location
- Configurable HTTP timeout

This partially addresses #2 